### PR TITLE
Replace math.pow with '^'

### DIFF
--- a/lua-lsp/unicode.lua
+++ b/lua-lsp/unicode.lua
@@ -4,9 +4,9 @@
 
 local unicode = {}
 
-local shift_6  = math.pow(2, 6)
-local shift_12 = math.pow(2, 12)
-local shift_18 = math.pow(2, 18)
+local shift_6  = 2^6
+local shift_12 = 2^12
+local shift_18 = 2^18
 -- The iterator is from the lua 5.3 reference manual:
 -- "[\0-\x7F\xC2-\xF4][\x80-\xBF]*"
 -- modifications are to keep 5.1-3 compat.


### PR DESCRIPTION
`math.pow` has been deprecated since 5.3 as documented [here](https://www.lua.org/manual/5.3/manual.html#8.2). The `^` syntax is supported [also in 5.1](https://www.lua.org/manual/5.1/manual.html#pdf-math.pow).