### PR TITLE
fix: Swap arguments to insure first param isn't missing

### DIFF
--- a/lua-lsp/methods.lua
+++ b/lua-lsp/methods.lua
@@ -565,7 +565,7 @@ method_handlers["textDocument/completion"] = function(params, id)
 						iname:sub(1, _iword:len()) == _iword then
 
 						local is_field = true
-						local subitems = make_completion_items(iname, val, is_method, is_field)
+						local subitems = make_completion_items(iname, val, is_field, is_method)
 						for _, item in ipairs(subitems) do
 							table.insert(items, item)
 						end

--- a/spec/complete_spec.lua
+++ b/spec/complete_spec.lua
@@ -172,7 +172,7 @@ return t
 					items = {{
 						detail = '"a"',
 						label = "string",
-						kind = completionKinds.Variable
+						kind = completionKinds.Field
 					}}
 				}, out)
 				callme = true
@@ -191,7 +191,7 @@ return t
 					items = {{
 						detail = '"a"',
 						label = "string",
-						kind = completionKinds.Variable
+						kind = completionKinds.Field
 					}}
 				}, out)
 				callme = true
@@ -258,7 +258,7 @@ return mystr.t
 				assert.same({
 					detail = 'True',
 					label  = 'test_example',
-					kind = completionKinds.Variable,
+					kind = completionKinds.Field,
 				}, out.items[1])
 				callme = true
 			end)
@@ -290,7 +290,7 @@ return mytbl.j
 				assert.same({
 					detail = '1',
 					label  = 'jeff',
-					kind = completionKinds.Variable,
+					kind = completionKinds.Field,
 				}, out.items[1])
 				callme = true
 			end)
@@ -395,7 +395,7 @@ return mytbl.f
 				assert.same({
 					detail = '"a"',
 					label  = 'field',
-					kind = completionKinds.Variable,
+					kind = completionKinds.Field,
 				}, out.items[1])
 				callme = true
 			end)


### PR DESCRIPTION
I noticed that "functions" were being identified as "methods" and that the first param of functions were missing, presumably to hide the `self` param in methods. It looked like the two parameters in the call to `make_completion_items` were swapped, so I fixed them.

## Some screenshots to show the difference

Before:
<img width="346" alt="Before the change" src="https://user-images.githubusercontent.com/333454/82890934-dfd39780-9f44-11ea-8c73-c455c5183185.png">

After:

<img width="391" alt="After the change" src="https://user-images.githubusercontent.com/333454/82890958-ec57f000-9f44-11ea-94d4-c0041f07aa4a.png">
