### PR TITLE
Insert functions as snippets

### DIFF
--- a/lua-lsp/methods.lua
+++ b/lua-lsp/methods.lua
@@ -130,6 +130,11 @@ local completionKinds = {
 	Reference = 18,
 }
 
+local insertTextFormats = {
+	Plain = 1,
+	Snippet = 2,
+}
+
 local function merge_(a, b)
 	for k, v in pairs(b) do a[k] = v end
 end
@@ -147,7 +152,7 @@ end
 
 -- this is starting to get silly.
 local function make_completion_items(k, val, isField, isInvoke, isVariant)
-	local item = { label = k }
+	local item = { label = k, insertTextFormat = insertTextFormats.Plain }
 
 	if val then
 		if not isVariant and val.variants then
@@ -190,6 +195,13 @@ local function make_completion_items(k, val, isField, isInvoke, isVariant)
 			else
 				table.insert(sig, " ??? ")
 			end
+
+			-- Construct a snippet insertion format from signature
+			local snippet_args = {}
+			for idx,val in ipairs(sig) do
+				table.insert(snippet_args, string.format("${%d:%s}", idx, val))
+			end
+			local snippet = string.format("%s(%s)$0", k, table.concat(snippet_args, ", "))
 
 			-- we still do the work associated with getting a signature,
 			-- because that work informs whether or not an function is a
@@ -252,7 +264,8 @@ local function make_completion_items(k, val, isField, isInvoke, isVariant)
 				ret = string.format("-> %s", ret)
 			end
 
-			item.insertText = k
+			item.insertText = snippet
+			item.insertTextFormat = insertTextFormats.Snippet
 			item.label = ("%s(%s) %s"):format(k, sig, ret)
 			item.documentation = val.description
 			if isInvoke then

--- a/spec/complete_spec.lua
+++ b/spec/complete_spec.lua
@@ -21,6 +21,8 @@ local completionKinds = {
 	Reference = 18,
 }
 
+local insertTextFormats = { Plain = 1, Snippet = 2, }
+
 describe("textDocument/completion", function()
 	it("returns nothing with no symbols", function()
 		mock_loop(function(rpc)
@@ -66,7 +68,7 @@ describe("textDocument/completion", function()
 				assert.same({
 					isIncomplete = false,
 					items = {
-						{label = "mySymbol", kind = completionKinds.Variable}
+						{label = "mySymbol", kind = completionKinds.Variable, insertTextFormat = insertTextFormats.Plain }
 					}
 				}, out)
 				callme = true
@@ -89,8 +91,8 @@ describe("textDocument/completion", function()
 				assert.same({
 					isIncomplete = false,
 					items = {
-						{label = "symbolA", kind = completionKinds.Variable},
-						{label="symbolB", kind = completionKinds.Variable}
+						{label = "symbolA", kind = completionKinds.Variable, insertTextFormat = insertTextFormats.Plain},
+						{label="symbolB", kind = completionKinds.Variable, insertTextFormat = insertTextFormats.Plain}
 					}
 				}, out)
 				callme = true
@@ -113,7 +115,7 @@ describe("textDocument/completion", function()
 				assert.same({
 					isIncomplete = false,
 					items = {
-						{label = "symbolC", kind = completionKinds.Variable}
+						{label = "symbolC", kind = completionKinds.Variable, insertTextFormat = insertTextFormats.Plain}
 					}
 				}, out)
 				callme = true
@@ -149,6 +151,7 @@ return t
 					detail = '<table>',
 					label  = 'tbl',
 					kind = completionKinds.Variable,
+					insertTextFormat = insertTextFormats.Plain,
 				}, out.items[1])
 				callme = true
 			end)
@@ -172,6 +175,7 @@ return t
 					items = {{
 						detail = '"a"',
 						label = "string",
+						insertTextFormat = insertTextFormats.Plain,
 						kind = completionKinds.Variable
 					}}
 				}, out)
@@ -191,6 +195,7 @@ return t
 					items = {{
 						detail = '"a"',
 						label = "string",
+						insertTextFormat = insertTextFormats.Plain,
 						kind = completionKinds.Variable
 					}}
 				}, out)
@@ -225,6 +230,7 @@ return tbl.a
 				assert.same({
 					detail = 'M<mymod>',
 					label  = 'tbl',
+					insertTextFormat = insertTextFormats.Plain,
 					kind = completionKinds.Module,
 				}, out.items[1])
 				callme = true
@@ -259,6 +265,7 @@ return mystr.t
 					detail = 'True',
 					label  = 'test_example',
 					kind = completionKinds.Variable,
+					insertTextFormat = insertTextFormats.Plain,
 				}, out.items[1])
 				callme = true
 			end)
@@ -291,6 +298,7 @@ return mytbl.j
 					detail = '1',
 					label  = 'jeff',
 					kind = completionKinds.Variable,
+					insertTextFormat = insertTextFormats.Plain,
 				}, out.items[1])
 				callme = true
 			end)
@@ -358,7 +366,8 @@ return my_f
 				assert.same({
 					detail = '<function>',
 					label  = 'my_fun(...) -> <table>',
-					insertText = 'my_fun',
+					insertText = 'my_fun(${1:...})$0',
+					insertTextFormat = insertTextFormats.Snippet,
 					kind = completionKinds.Function,
 				}, out.items[1])
 				callme = true
@@ -396,6 +405,7 @@ return mytbl.f
 					detail = '"a"',
 					label  = 'field',
 					kind = completionKinds.Variable,
+					insertTextFormat = insertTextFormats.Plain,
 				}, out.items[1])
 				callme = true
 			end)


### PR DESCRIPTION
This changeset adds snippet support to function or method completion items so that an editor will insert tab stops for parameters. I need to go back through the spec to ensure I haven't missed anything, but I wanted to open it up so others could take a look and so far for my uses it works well.

### Changes

* Added [`insertTextFormat`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion) to completion items, using `Plain` for all items except functions and methods, which use `Snippet`
* Modified the `insertText` for function/method items to insert parens and use tab stops for each parameter. For example, given the initial text `math.fm`, completing the item described as `math.fmod(x, y)` inserts `math.fmod(${1:x}, ${2:y})` instead of `math.fmod`.

### Screenshots

Before:
![lua-lsp-now](https://user-images.githubusercontent.com/333454/82891875-62108b80-9f46-11ea-99e2-0c894ceb3993.gif)

After:
![lua-lsp-snippets](https://user-images.githubusercontent.com/333454/82891893-689f0300-9f46-11ea-9025-391c7c41b8c3.gif)