### PR TITLE
add lua-lsp.json to rockspec

### DIFF
--- a/lua-lsp-scm-1.rockspec
+++ b/lua-lsp-scm-1.rockspec
@@ -36,6 +36,7 @@ build = {
       ["lua-lsp.data.luajit-2_0"] = "lua-lsp/data/luajit-2_0.lua",
       ["lua-lsp.data._test"] = "lua-lsp/data/_test.lua",
       ["lua-lsp.formatting"] = "lua-lsp/formatting.lua",
+      ["lua-lsp.json"] = "lua-lsp/json.lua",
       ["lua-lsp.log"] = "lua-lsp/log.lua",
       ["lua-lsp.loop"] = "lua-lsp/loop.lua",
       ["lua-lsp.lua-parser.parser"] = "lua-lsp/lua-parser/parser.lua",


### PR DESCRIPTION
I don't know much about lua and luarocks but that seems to be missing ?
I am getting
```
/usr/local/opt/lua/bin/lua5.3: /usr/local/share/lua/5.3/lua-lsp/rpc.lua:2: module 'lua-lsp.json' not found:No LuaRocks module found for lua-lsp.json
```
when trying to run it