### PR TITLE
Update Luarocks usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,8 @@ For code formatting, we currently support Formatter and LCF. Formatter is 5.1
 only, whereas lcf is 5.3 only.
 5.1:
 ```
-$ luarocks-5.1 install Formatter
-$ luarocks-5.3 install lcf
+$ luarocks --lua-version=5.1 install Formatter
+$ luarocks --lua-version=5.3 install lcf
 ```
 If you have another package you'd like to see integrated, feel free to leave an
 issue/PR. Other plugins are always welcome, especially if they provide


### PR DESCRIPTION
## Motivation

For me the examples with `luarocks-5.1`/`luarocks-5.3` did not work:
```
> luarocks-5.1 install Formatter
zsh: command not found: luarocks-5.1
```

What worked for me was setting the luarocks option `lua-version`:
```
 luarocks install --lua-version=5.1 Formatter
```

## Changes

Updated the usage of luarocks to specify the language version via cli option.

## Concerns

In case the issue is not in the example, but rather something wrong with my environment, feel free to dismiss this contribution.
